### PR TITLE
fix: handle string decoder returning undefined

### DIFF
--- a/src/deobfuscator/inlineDecodedStrings.ts
+++ b/src/deobfuscator/inlineDecodedStrings.ts
@@ -11,10 +11,7 @@ export default {
   visitor: options => ({
     CallExpression(path) {
       options?.decoders.forEach(decoder => {
-        const matcher = m.callExpression(
-          m.identifier(decoder.name),
-          m.anything()
-        );
+        const matcher = m.callExpression(m.identifier(decoder.name), m.anything());
 
         if (matcher.match(path.node) && t.isLiteral(path.node.arguments[0])) {
           const args = path.node.arguments.map(arg => {
@@ -22,7 +19,9 @@ export default {
               return arg.value;
             }
           });
-          path.replaceWith(t.stringLiteral(options.vm.decode(decoder, args)));
+
+          let decoded: string | undefined = options.vm.decode(decoder, args);
+          path.replaceWith(decoded ? t.stringLiteral(decoded) : t.tsUndefinedKeyword());
           this.changes++;
         }
       });

--- a/src/deobfuscator/inlineDecodedStrings.ts
+++ b/src/deobfuscator/inlineDecodedStrings.ts
@@ -20,8 +20,8 @@ export default {
             }
           });
 
-          let decoded: string | undefined = options.vm.decode(decoder, args);
-          path.replaceWith(decoded ? t.stringLiteral(decoded) : t.tsUndefinedKeyword());
+          let decoded = options.vm.decode(decoder, args);
+          path.replaceWith(decoded ? t.stringLiteral(decoded) : t.identifier(String(decoded)));
           this.changes++;
         }
       });

--- a/test/__snapshots__/deobfuscator.test.ts.snap
+++ b/test/__snapshots__/deobfuscator.test.ts.snap
@@ -31,6 +31,7 @@ function hi() {
     })();
   })();
   console.log(\\"Hello World!\\");
+  console.log(undefined);
 }
 hi();
 function a(b) {

--- a/test/samples/obfuscator.io.js
+++ b/test/samples/obfuscator.io.js
@@ -81,7 +81,8 @@ function hi() {
       !f[l(0xc5)](h + l(0xc6)) || !g[l(0xc5)](h + 'input') ? h('0') : a();
     })();
   })(),
-    console[m(0xc7)](m(0xc8));
+  console[m(0xc7)](m(0xc8));
+  console[m(0xc7)](m(0xc811));
 }
 function d(a, b) {
   var e = c();


### PR DESCRIPTION
If the decoder function returns "undefined" babel, it will cause an error because it expects a string.

an idea to check for other types than just undefined and string.

this might not be the best solution I'd be happy to make any suggested changes