### PR TITLE
chore: add cli-wrapper.js as workaround for pnpm install warning

### DIFF
--- a/packages/webcrack/package.json
+++ b/packages/webcrack/package.json
@@ -7,9 +7,10 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "bin": "dist/cli.js",
+  "bin": "src/cli-wrapper.js",
   "files": [
-    "dist"
+    "dist",
+    "src/cli-wrapper.js"
   ],
   "scripts": {
     "build": "node esbuild.config.js && tsc -p tsconfig.build.json",

--- a/packages/webcrack/src/cli-wrapper.js
+++ b/packages/webcrack/src/cli-wrapper.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+// workaround for pnpm install warning "Failed to create bin"
+// when dist/cli.js does not-yet exist
+import "../dist/cli.js"


### PR DESCRIPTION
fix #58

alternative: add a `prepare` script to `packages/webcrack/package.json`
to run build before install

```
  "scripts": {
    "prepare": "npm run build",
```

[publishconfig](https://pnpm.io/package_json#publishconfig) feels wrong
there should be no difference between local build and published build
