### PR TITLE
[docs] Improve API docs related to `mappings` option

### DIFF
--- a/apps/docs/src/guide/api.md
+++ b/apps/docs/src/guide/api.md
@@ -89,6 +89,10 @@ await webcrack(code, {
 });
 ```
 
+Other options include:
+
+- `mappings`: The `mappings` option takes a function that receives an instance of [@codemod/matchers](https://github.com/codemod-js/codemod/tree/main/packages/matchers#readme)
+
 ## Browser Usage & Sandbox
 
 The `sandbox` option has to be passed when trying to deobfuscate string arrays in a browser.
@@ -129,6 +133,8 @@ const result = await webcrack('function _0x317a(){....', { sandbox: evalCode });
 ## Customize Paths
 
 Useful for reverse-engineering and tracking changes across multiple versions of a bundle.
+
+The `mappings` option takes a function that receives an instance of [@codemod/matchers](https://github.com/codemod-js/codemod/tree/main/packages/matchers#readme).
 
 If a matching node in the AST of a module is found, it will be renamed to the given path.
 

--- a/apps/docs/src/guide/api.md
+++ b/apps/docs/src/guide/api.md
@@ -91,7 +91,7 @@ await webcrack(code, {
 
 Other options include:
 
-- `mappings`: The `mappings` option takes a function that receives an instance of [@codemod/matchers](https://github.com/codemod-js/codemod/tree/main/packages/matchers#readme)
+- `mappings`: The `mappings` option takes a function that receives an instance of [@codemod/matchers](https://github.com/codemod-js/codemod/tree/main/packages/matchers#readme), and returns an object that maps any matching nodes, to the path specified in the object key.
 
 ## Browser Usage & Sandbox
 
@@ -134,7 +134,7 @@ const result = await webcrack('function _0x317a(){....', { sandbox: evalCode });
 
 Useful for reverse-engineering and tracking changes across multiple versions of a bundle.
 
-The `mappings` option takes a function that receives an instance of [@codemod/matchers](https://github.com/codemod-js/codemod/tree/main/packages/matchers#readme).
+The `mappings` option takes a function that receives an instance of [@codemod/matchers](https://github.com/codemod-js/codemod/tree/main/packages/matchers#readme), and returns an object that maps any matching nodes, to the path specified in the object key.
 
 If a matching node in the AST of a module is found, it will be renamed to the given path.
 


### PR DESCRIPTION
Improve docs related to `mappings` option, and how it relates to `@codemod/matchers`

Added a few extra snippets of docs related to the `mappings` option, as it wasn't immediately clear to me how `@codemod/matchers` related to the example given.

I'm sure the wording could be improved, but wanted to provide something as a starting point at the very least.