### PR TITLE
mangle: additional sources for init names

### DIFF
--- a/packages/webcrack/src/transforms/mangle.ts
+++ b/packages/webcrack/src/transforms/mangle.ts
@@ -85,6 +85,10 @@ function generateExpressionName(
     return 'LN' + expression.node.value.toString();
   } else if (expression.isStringLiteral()) {
     return 'LS' + titleCase(expression.node.value);
+  } else if (expression.isObjectExpression()) {
+    return 'O';
+  } else if (expression.isArrayExpression()) {
+    return 'A';
   } else {
     return undefined;
   }

--- a/packages/webcrack/src/transforms/mangle.ts
+++ b/packages/webcrack/src/transforms/mangle.ts
@@ -84,7 +84,7 @@ function generateExpressionName(
   } else if (expression.isNumericLiteral()) {
     return 'LN' + expression.node.value.toString();
   } else if (expression.isStringLiteral()) {
-    return 'LS' + titleCase(expression.node.value);
+    return 'LS' + titleCase(expression.node.value).slice(0, 100);
   } else if (expression.isObjectExpression()) {
     return 'O';
   } else if (expression.isArrayExpression()) {

--- a/packages/webcrack/src/transforms/mangle.ts
+++ b/packages/webcrack/src/transforms/mangle.ts
@@ -96,6 +96,6 @@ function generateExpressionName(
 
 function titleCase(str: string) {
   return str
-    .replace(/(?:^|\s)([a-z])/g, (_, m) => m.toUpperCase())
+    .replace(/(?:^|\s)([a-z])/g, (_, m) => (m as string).toUpperCase())
     .replace(/[^a-zA-Z0-9$_]/g, '');
 }

--- a/packages/webcrack/src/transforms/mangle.ts
+++ b/packages/webcrack/src/transforms/mangle.ts
@@ -81,11 +81,17 @@ function generateExpressionName(
     );
   } else if (expression.isThisExpression()) {
     return 'this';
+  } else if (expression.isNumericLiteral()) {
+    return 'LN' + expression.node.value.toString();
+  } else if (expression.isStringLiteral()) {
+    return 'LS' + titleCase(expression.node.value);
   } else {
     return undefined;
   }
 }
 
 function titleCase(str: string) {
-  return str.length > 0 ? str[0].toUpperCase() + str.slice(1) : str;
+  return str
+    .replace(/(?:^|\s)([a-z])/g, (_, m) => m.toUpperCase())
+    .replace(/[^a-zA-Z0-9$_]/g, '');
 }

--- a/packages/webcrack/test/mangle.test.ts
+++ b/packages/webcrack/test/mangle.test.ts
@@ -5,7 +5,7 @@ import mangle from '../src/transforms/mangle';
 const expectJS = testTransform(mangle);
 
 test('variable', () => {
-  expectJS('let x = 1;').toMatchInlineSnapshot('let v = 1;');
+  expectJS('let x = 1;').toMatchInlineSnapshot('let vLN1 = 1;');
   expectJS('let x = exports;').toMatchInlineSnapshot(`let vExports = exports;`);
   expectJS('let x = () => {};').toMatchInlineSnapshot(`let vF = () => {};`);
   expectJS('let x = class {};').toMatchInlineSnapshot(`let vC = class {};`);
@@ -23,6 +23,32 @@ test('variable', () => {
     const nodeFs = require("node:fs");
     const nodeFs2 = require("node:fs");
   `);
+
+  expectJS(
+    `
+    let a = 100;
+    let b = 200;
+    let c = 300;
+  `,
+  ).toMatchInlineSnapshot(`
+    let vLN100 = 100;
+    let vLN200 = 200;
+    let vLN300 = 300;
+  `);
+
+  expectJS(
+    `
+    let a = "hello world";
+    let b = 100;
+    let c = 200;
+    let d = 300;
+  `,
+  ).toMatchInlineSnapshot(`
+    let vLSHelloWorld = "hello world";
+    let vLN100 = 100;
+    let vLN200 = 200;
+    let vLN300 = 300;
+  `);
 });
 
 test('ignore exports', () => {
@@ -38,7 +64,7 @@ test('only rename _0x variable', () => {
     `,
     (id) => id.startsWith('_0x'),
   ).toMatchInlineSnapshot(`
-    let v = 1;
+    let vLN1 = 1;
     let foo = 2;
   `);
 });
@@ -49,7 +75,9 @@ test('class', () => {
 
 test('function', () => {
   expectJS('function abc() {}').toMatchInlineSnapshot('function f() {}');
-  expectJS('export default function x() {}').toMatchInlineSnapshot(`export default function f() {}`);
+  expectJS('export default function x() {}').toMatchInlineSnapshot(
+    `export default function f() {}`,
+  );
 });
 
 test('parameters', () => {

--- a/packages/webcrack/test/mangle.test.ts
+++ b/packages/webcrack/test/mangle.test.ts
@@ -12,6 +12,8 @@ test('variable', () => {
   expectJS('let x = Array(100);').toMatchInlineSnapshot(
     `let vArray = Array(100);`,
   );
+  expectJS('let x = []').toMatchInlineSnapshot(`let vA = [];`);
+  expectJS('let x = {}').toMatchInlineSnapshot(`let vO = {};`);
   expectJS('let [x] = 1;').toMatchInlineSnapshot(`let [v] = 1;`);
   expectJS('const x = require("fs");').toMatchInlineSnapshot(
     `const fs = require("fs");`,

--- a/packages/webcrack/test/mangle.test.ts
+++ b/packages/webcrack/test/mangle.test.ts
@@ -41,15 +41,11 @@ test('variable', () => {
   expectJS(
     `
     let a = "hello world";
-    let b = 100;
-    let c = 200;
-    let d = 300;
+    let b = "foo-bar-🗿-ä";
   `,
   ).toMatchInlineSnapshot(`
     let vLSHelloWorld = "hello world";
-    let vLN100 = 100;
-    let vLN200 = 200;
-    let vLN300 = 300;
+    let vLSFoobar = "foo-bar-🗿-ä";
   `);
 
   const veryLongString = 'a'.repeat(1000);

--- a/packages/webcrack/test/mangle.test.ts
+++ b/packages/webcrack/test/mangle.test.ts
@@ -51,6 +51,11 @@ test('variable', () => {
     let vLN200 = 200;
     let vLN300 = 300;
   `);
+
+  const veryLongString = 'a'.repeat(1000);
+  expectJS(`let x = "${veryLongString}";`).toMatchInlineSnapshot(
+    `let vLSA${veryLongString.slice(0, 99)} = "${veryLongString}";`,
+  );
 });
 
 test('ignore exports', () => {


### PR DESCRIPTION
partially addresses #154 by incorporating more kinds of init expressions (numeric & string literals, array & object expressions).

The LN/LS prefix (literal string) should probably removed, just added it for clarity.