### PR TITLE
fix: dont unpack unsafe strings

### DIFF
--- a/packages/webcrack/src/deobfuscate/evaluate-globals.ts
+++ b/packages/webcrack/src/deobfuscate/evaluate-globals.ts
@@ -34,8 +34,10 @@ export default {
               globalThis,
               arg.current!,
             );
-            path.replaceWith(t.stringLiteral(value));
-            this.changes++;
+            if (isStringSafe(value)) {
+              path.replaceWith(t.stringLiteral(value));
+              this.changes++;
+            }
           } catch {
             // ignore
           }
@@ -44,3 +46,9 @@ export default {
     };
   },
 } satisfies Transform;
+
+// Don't unpack strings which contain weird unicode characters which can cause issues when the file
+// is parsed by other tools after the transformation.
+function isStringSafe(s: string) {
+  return /^[\x00-\x7F]*$/.test(s);
+}

--- a/packages/webcrack/src/deobfuscate/test/evaluate-globals.test.ts
+++ b/packages/webcrack/src/deobfuscate/test/evaluate-globals.test.ts
@@ -10,6 +10,10 @@ test('atob', () =>
 test('atob that throws', () =>
   expectJS('atob("-")').toMatchInlineSnapshot(`atob("-");`));
 
+const unsafe = `atob("zlHZOQnYtsBGvZHVYfNu236gabh5mIaAdhUh/dHa/vLuPTlVqRYW/ubY8cABLU4lnuzJ5Bn7ZhOWMQEZ8QReDI40GRzJqfahBg5TBiH4MOA+Vis+OeZI7jag47iR5fbDmvfueXVaCtM9qQzHOnh1GX1HqlkUSTvoWmUWOfjfylMnaQyy+txE2XYQahPmCcpGGvVg+WdZitCnKQ8KumttmdsrKg15yR+K2vmHuZPvSkQ46SW6esjBWVTo6vndiTZ/mv5XeZDMCjGeqcGMOlJSGdKSqnG7SY27WpzWOfk+turZZU5zTHmnGi/sxcGKuCufYTE6QlVcYNVlFWPwwcXmvC5UFxoHUtSXmgClFros4Q==");`;
+test('atob with unsafe string', () =>
+  expectJS(unsafe).toMatchInlineSnapshot(unsafe));
+
 test('unescape', () =>
   expectJS('unescape("%41")').toMatchInlineSnapshot('"A";'));
 


### PR DESCRIPTION
I'm not entirely sure which part of the string is causing the issues, but when trying to process using python afterwards, it produces garbage.