### PR TITLE
mangle: reduce generateExpressionName's isStringLiteral renamed identifier length from 100 to 20

### DIFF
--- a/packages/webcrack/src/transforms/mangle.ts
+++ b/packages/webcrack/src/transforms/mangle.ts
@@ -86,7 +86,7 @@ function generateExpressionName(
   } else if (expression.isNumericLiteral()) {
     return 'LN' + expression.node.value.toString();
   } else if (expression.isStringLiteral()) {
-    return 'LS' + titleCase(expression.node.value).slice(0, 100);
+    return 'LS' + titleCase(expression.node.value).slice(0, 20);
   } else if (expression.isObjectExpression()) {
     return 'O';
   } else if (expression.isArrayExpression()) {

--- a/packages/webcrack/test/mangle.test.ts
+++ b/packages/webcrack/test/mangle.test.ts
@@ -48,6 +48,10 @@ test('variable', () => {
     let vLSFoobar = "foo-bar-🗿-ä";
   `);
 
+  expectJS(`let x = "";`).toMatchInlineSnapshot(
+    `let vLS = "";`,
+  );
+
   const veryLongString = 'a'.repeat(1000);
   expectJS(`let x = "${veryLongString}";`).toMatchInlineSnapshot(
     `let vLSA${veryLongString.slice(0, 19)} = "${veryLongString}";`,

--- a/packages/webcrack/test/mangle.test.ts
+++ b/packages/webcrack/test/mangle.test.ts
@@ -50,7 +50,7 @@ test('variable', () => {
 
   const veryLongString = 'a'.repeat(1000);
   expectJS(`let x = "${veryLongString}";`).toMatchInlineSnapshot(
-    `let vLSA${veryLongString.slice(0, 99)} = "${veryLongString}";`,
+    `let vLSA${veryLongString.slice(0, 19)} = "${veryLongString}";`,
   );
 });
 


### PR DESCRIPTION
Followup to:

- #155

Fixes:

- https://github.com/j4k0xb/webcrack/pull/155/files#r1986625847
  - > 100 chars is still pretty huge for a variable name yeah? Would an even smaller size be better here? Like how often are strings going to reasonably clash with one another at like 20 chars or so?
    > 
    > Say I have some text in a variable, and it's truncated to 100 chars for the name, but then it's referenced many times across my code.. spamming a var name as long as `1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890` many many times throughout the unminified code seems... less than ideal.
- https://github.com/j4k0xb/webcrack/pull/155/files#r1987088408
  - > Mangle
    > - Primarily designed for providing some context and getting rid of obfuscated/minified names
    > - Not really suitable for making the output stable (running webcrack multiple times changes it)
    > - 20 length limit sounds good to improve readability