### PR TITLE
feat: deobfuscate object member jsx

### DIFF
--- a/packages/webcrack/src/transforms/jsx-new.ts
+++ b/packages/webcrack/src/transforms/jsx-new.ts
@@ -41,7 +41,7 @@ export default {
     const key = m.capture(m.anyExpression());
 
     const jsxFunction = m.capture(m.or(...DEFAULT_PRAGMA_CANDIDATES));
-    // jsx(type, props, key?) or (0, r.jsx)(type, props, key?)
+    // jsx(type, props, key?) or (0, r.jsx)(type, props, key?) or obj.jsx(type, props, key?)
     const jsxMatcher = m.callExpression(
       m.or(
         m.identifier(jsxFunction),
@@ -49,6 +49,11 @@ export default {
           m.numericLiteral(0),
           constMemberExpression(m.identifier(), jsxFunction),
         ]),
+        m.memberExpression(
+          m.anyExpression(),
+          m.identifier(jsxFunction),
+          false
+        )
       ),
       m.anyList(type, props, m.slice({ min: 0, max: 1, matcher: key })),
     );

--- a/packages/webcrack/test/jsx-new.test.ts
+++ b/packages/webcrack/test/jsx-new.test.ts
@@ -93,3 +93,12 @@ test('props with escaped strings', () =>
 
 test('indirect jsx call', () =>
   expectJS('(0, r.jsx)("div", {})').toMatchInlineSnapshot('<div />;'));
+
+test('object member jsxs and jsx', () =>
+  expectJS('r.jsxs(Foo, { bar: 1, children: [r.jsx(Child, {})] });').toMatchInlineSnapshot(
+    '<Foo bar={1}><Child /></Foo>;',
+  ));
+
+
+
+

--- a/packages/webcrack/test/jsx-new.test.ts
+++ b/packages/webcrack/test/jsx-new.test.ts
@@ -95,10 +95,6 @@ test('indirect jsx call', () =>
   expectJS('(0, r.jsx)("div", {})').toMatchInlineSnapshot('<div />;'));
 
 test('object member jsxs and jsx', () =>
-  expectJS('r.jsxs(Foo, { bar: 1, children: [r.jsx(Child, {})] });').toMatchInlineSnapshot(
-    '<Foo bar={1}><Child /></Foo>;',
-  ));
-
-
-
-
+  expectJS(
+    'r.jsxs(Foo, { bar: 1, children: [r.jsx(Child, {})] });',
+  ).toMatchInlineSnapshot('<Foo bar={1}><Child /></Foo>;'));


### PR DESCRIPTION
I have code like this, which doesn't transform
```jsx
const v_0x3e0f9c2 = _0x3e0f9c(function ({
  caption: _0x3b2702,
  style: _0x17abfd
}) {
  const {
    availableSize: _0x55b727
  } = u();
  const v6 = _0x55b727.y * v5;
  const v_0x3fd2e9 = _0x3fd2e9([v6 * 0.75, v6 * 0.5]);
  const v_0x16838f2 = _0x16838f(_0x17abfd, _0x3b2702.text);
  return _0x38625f.jsx(_0x435e8a, {
    padding: {
      top: _0x55b727.y - v_0x16838f2.height - v_0x3fd2e9.y * 2,
      x: (_0x55b727.x - v_0x16838f2.width) / 2 - v_0x3fd2e9.x
    },
    style: p2 => p2 < _0x3b2702.startMs ? {
      alpha: 0.5
    } : (p2 - _0x3b2702.startMs < 100, {
      alpha: 1
    }),
    defaultSpring: v4,
    children: _0x38625f.jsx(_0x476c18.Text, {
      text: _0x3b2702.text,
      style: _0x17abfd
    })
  });
});
```

In this PR I added support for cases like this