### PR TITLE
update README to link to API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,7 @@ console.log(result.code);
 console.log(result.bundle);
 await result.save('output-dir');
 ```
+
+Further Reading:
+
+- [apps/docs/src/guide/api.md](apps/docs/src/guide/api.md)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ webcrack input.js > output.js
 webcrack bundle.js -o output-dir
 ```
 
+[CLI Reference](https://webcrack.netlify.app/docs/guide/cli.html)
+
 ## API
 
 ```bash
@@ -57,6 +59,4 @@ console.log(result.bundle);
 await result.save('output-dir');
 ```
 
-Further Reading:
-
-- [apps/docs/src/guide/api.md](apps/docs/src/guide/api.md)
+[API Reference](https://webcrack.netlify.app/docs/guide/api.html)


### PR DESCRIPTION
I noticed that there were more detailed API docs:

- https://github.com/j4k0xb/webcrack/blob/master/apps/docs/src/guide/api.md

But they weren't currently linked to from the API section of `README.md`:

- https://github.com/j4k0xb/webcrack#api

So added a link to them.

I wasn't sure of the best wording/way to add it, so feel free to tweak/update as you like.