### PR TITLE
Tiny type-safety fix

### DIFF
--- a/packages/webcrack/src/cli.ts
+++ b/packages/webcrack/src/cli.ts
@@ -16,9 +16,9 @@ const { version, description } = JSON.parse(
 debug.enable('webcrack:*');
 
 interface Options {
-  force: boolean;
+  force?: boolean;
   output?: string;
-  mangle: boolean;
+  mangle?: boolean;
   jsx: boolean;
   unpack: boolean;
   deobfuscate: boolean;


### PR DESCRIPTION
The only options that `commander` is guaranteed to provide values for are the ones that are specified as `--no-x`