### PR TITLE
fix: return early if no decoder calls found

### DIFF
--- a/packages/webcrack/src/deobfuscate/inline-decoded-strings.ts
+++ b/packages/webcrack/src/deobfuscate/inline-decoded-strings.ts
@@ -16,6 +16,8 @@ export default {
     const calls = options.vm.decoders.flatMap((decoder) =>
       decoder.collectCalls(),
     );
+    if (calls.length === 0) return;
+    
     const decodedValues = await options.vm.decode(calls);
 
     for (let i = 0; i < calls.length; i++) {


### PR DESCRIPTION
Add an early return when no decoder calls are collected.

This prevents the crash reported in #201 and allows execution to complete successfully. The change is a defensive workaround; the root cause still needs investigation.

Maybe anewer version of https://github.com/javascript-obfuscator/javascript-obfuscator is generating patterns that webcrack can no longer decode, resulting in an empty call set.